### PR TITLE
Add flatcar to PXE-Z

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PXE-Z
 
-A python project that aims to quickly and easily setup PXE on RHEL and Debian systems.
+A python project that aims to quickly and easily setup PXE on RHEL and Debian systems. If you are developing or running this from Mac or Windows, be sure to first install `vagrant`, and a viable hypervisor tool such as `Virtual Box` so that you can follow the directions below.
 
 Vagrant
 ====

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,10 +4,10 @@
 #    https://github.com/ryanhartje/pxe-z
 
 $script = <<SCRIPT
-# download required packages
+
 yum update
 yum install -y git vim 
-# download pxe-z 
+
 git clone https://github.com/ryanhartje/pxe-z
 SCRIPT
 

--- a/pxe_z.py
+++ b/pxe_z.py
@@ -66,8 +66,8 @@ def get_images():
          'url': 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/'
                 'current/images/netboot/netboot.tar.gz'},
         {'id': 3, 'name': 'Debian Jessie 8.4', 'type': 'iso',
-         'url': 'http://cdimage.debian.org/debian-cd/8.4.0/amd64/iso-cd/'
-                'debian-8.4.0-amd64-netinst.iso'},
+         'url': 'http://cdimage.debian.org/debian-cd/10.7.0/amd64/iso-cd/'
+                'debian-10.7.0-amd64-netinst.iso'},
         {'id': 4, 'name': 'Kali Linux 2016.1', 'type': 'iso',
          'url': 'http://cdimage.kali.org/kali-2016.1/kali-linux-2016.1-amd64.iso'},
         {'id': 5, 'name': 'Gparted', 'type': 'iso',

--- a/pxe_z.py
+++ b/pxe_z.py
@@ -65,7 +65,7 @@ def get_images():
         {'id': 2, 'name': 'Ubuntu 14.04', 'type': 'tar',
          'url': 'http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/'
                 'current/images/netboot/netboot.tar.gz'},
-        {'id': 3, 'name': 'Debian Jessie 8.4', 'type': 'iso',
+        {'id': 3, 'name': 'Debian Jessie 10.7 [amd64]', 'type': 'iso',
          'url': 'http://cdimage.debian.org/debian-cd/10.7.0/amd64/iso-cd/'
                 'debian-10.7.0-amd64-netinst.iso'},
         {'id': 4, 'name': 'Kali Linux 2016.1', 'type': 'iso',


### PR DESCRIPTION
This PR exists to update PXE-Z to add `flatcar`. As a consequence of this project not receiving updates in the last 3-4 years, there are some other general items of housekeeping that will land in this PR as well.